### PR TITLE
Select alternative printing to display

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
+    jest: true,
   },
   extends: ['eslint:recommended', 'plugin:react/recommended', 'prettier'],
   parserOptions: {

--- a/__tests__/components/CardManager.test.js
+++ b/__tests__/components/CardManager.test.js
@@ -7,12 +7,25 @@ import { Button } from 'semantic-ui-react';
 import { shallow, mount } from 'enzyme';
 
 describe('CardManager', () => {
-  const mockCardData = {
-    image_uris: {
-      large: 'image uri',
-    },
-    scryfall_uri: 'card uri',
-    rulings_uri: 'rulings uri',
+  const mockCardsData = {
+    data: [
+      {
+        id: '1',
+        image_uris: {
+          large: 'image uri',
+        },
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
+      },
+      {
+        id: '2',
+        image_uris: {
+          large: 'image uri',
+        },
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
+      },
+    ],
   };
   const mockRulingsData = {
     data: [],
@@ -23,8 +36,8 @@ describe('CardManager', () => {
 
   beforeEach(() => {
     fetchMock.get(
-      'begin:https://api.scryfall.com/cards/named?exact=',
-      mockCardData
+      'begin:https://api.scryfall.com/cards/search?order=released&q=%21%E2%80%9C',
+      mockCardsData
     );
     fetchMock.get('rulings uri', mockRulingsData);
     fetchMock.get('https://whatsthatdo.net/share/share-code', mockShareData);

--- a/__tests__/components/CardResult.test.js
+++ b/__tests__/components/CardResult.test.js
@@ -7,13 +7,28 @@ import RulingsModal from '../../components/RulingsModal';
 import { Button, Icon } from 'semantic-ui-react';
 import { mount } from 'enzyme';
 
+test('blank', () => {});
+
 describe('CardResult', () => {
-  const mockCardData = {
-    image_uris: {
-      large: 'image uri',
-    },
-    scryfall_uri: 'card uri',
-    rulings_uri: 'rulings uri',
+  const mockCardsData = {
+    data: [
+      {
+        id: '1',
+        image_uris: {
+          large: 'image uri',
+        },
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
+      },
+      {
+        id: '2',
+        image_uris: {
+          large: 'image uri',
+        },
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
+      },
+    ],
   };
   const mockRulingsData = {
     data: [
@@ -37,25 +52,47 @@ describe('CardResult', () => {
       },
     ],
   };
-  const mockCardDataWithFaces = {
-    card_faces: [
+  const mockCardsDataWithFaces = {
+    data: [
       {
-        image_uris: {
-          large: 'image uri face 1',
-        },
+        id: '1',
+        card_faces: [
+          {
+            image_uris: {
+              large: 'image uri face 1',
+            },
+          },
+          {
+            image_uris: {
+              large: 'image uri face 2',
+            },
+          },
+        ],
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
       },
       {
-        image_uris: {
-          large: 'image uri face 2',
-        },
+        id: '2',
+        card_faces: [
+          {
+            image_uris: {
+              large: 'image uri face 1',
+            },
+          },
+          {
+            image_uris: {
+              large: 'image uri face 2',
+            },
+          },
+        ],
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
       },
     ],
-    scryfall_uri: 'card uri',
-    rulings_uri: 'rulings uri',
   };
 
   beforeEach(() => {
-    fetchMock.getOnce('*', mockCardData);
+    fetchMock.getOnce('*', mockCardsData);
     fetchMock.getOnce('rulings uri', mockRulingsData);
   });
 
@@ -74,10 +111,10 @@ describe('CardResult', () => {
     setImmediate(() => {
       expect(fetchMock.calls()).toHaveLength(2);
       expect(fetchMock.calls()[0][0]).toEqual(
-        'https://api.scryfall.com/cards/named?exact=Goblin%20Balloon%20Brigade'
+        'https://api.scryfall.com/cards/search?order=released&q=%21%E2%80%9CGoblin%20Balloon%20Brigade%E2%80%9D+include%3Aextras&unique=prints'
       );
       expect(fetchMock.calls()[1][0]).toEqual('rulings uri');
-      expect(wrapper.state('card')).toEqual(mockCardData);
+      expect(wrapper.state('card')).toEqual(mockCardsData.data[0]);
       expect(wrapper.state('rulings')).toEqual(mockRulingsData.data);
 
       done();
@@ -105,7 +142,7 @@ describe('CardResult', () => {
 
   test('renders face image', done => {
     fetchMock.restore();
-    fetchMock.getOnce('*', mockCardDataWithFaces);
+    fetchMock.getOnce('*', mockCardsDataWithFaces);
     fetchMock.getOnce('rulings uri', mockRulingsData);
 
     const wrapper = mount(
@@ -141,7 +178,7 @@ describe('CardResult', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.find('.actions').find(Button)).toHaveLength(4);
+      expect(wrapper.find('.actions').find(Button)).toHaveLength(5);
       const button = wrapper
         .find('.actions')
         .find(Button)
@@ -163,7 +200,7 @@ describe('CardResult', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.find('.actions').find(Button)).toHaveLength(4);
+      expect(wrapper.find('.actions').find(Button)).toHaveLength(5);
       const button = wrapper
         .find('.actions')
         .find(Button)
@@ -176,7 +213,7 @@ describe('CardResult', () => {
 
   test('renders disabled rulings button if no rulings', done => {
     fetchMock.restore();
-    fetchMock.getOnce('*', mockCardData);
+    fetchMock.getOnce('*', mockCardsData);
     fetchMock.getOnce('rulings uri', { data: [] });
 
     const wrapper = mount(
@@ -190,7 +227,7 @@ describe('CardResult', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.find('.actions').find(Button)).toHaveLength(4);
+      expect(wrapper.find('.actions').find(Button)).toHaveLength(5);
       const button = wrapper
         .find('.actions')
         .find(Button)
@@ -224,7 +261,7 @@ describe('CardResult', () => {
 
   test('shows flip button if double faced', done => {
     fetchMock.restore();
-    fetchMock.getOnce('*', mockCardDataWithFaces);
+    fetchMock.getOnce('*', mockCardsDataWithFaces);
     fetchMock.getOnce('rulings uri', mockRulingsData);
 
     const wrapper = mount(
@@ -250,7 +287,7 @@ describe('CardResult', () => {
 
   test('shows other face when flip button is clicked', done => {
     fetchMock.restore();
-    fetchMock.getOnce('*', mockCardDataWithFaces);
+    fetchMock.getOnce('*', mockCardsDataWithFaces);
     fetchMock.getOnce('rulings uri', mockRulingsData);
 
     const wrapper = mount(

--- a/__tests__/components/CardResult.test.js
+++ b/__tests__/components/CardResult.test.js
@@ -90,6 +90,18 @@ describe('CardResult', () => {
       },
     ],
   };
+  const mockCardsDataWithOnePrinting = {
+    data: [
+      {
+        id: '1',
+        image_uris: {
+          large: 'image uri',
+        },
+        scryfall_uri: 'card uri',
+        rulings_uri: 'rulings uri',
+      },
+    ],
+  };
 
   beforeEach(() => {
     fetchMock.getOnce('*', mockCardsData);
@@ -317,6 +329,52 @@ describe('CardResult', () => {
         'image uri face 2',
       ]);
       expect(wrapper.find(CardImage).prop('indexShowing')).toEqual(1);
+      done();
+    });
+  });
+
+  test('does not show printings button if only one printing', done => {
+    fetchMock.restore();
+    fetchMock.getOnce('*', mockCardsDataWithOnePrinting);
+    fetchMock.getOnce('rulings uri', mockRulingsData);
+    const wrapper = mount(
+      <CardResult
+        name="Goblin Balloon Brigade"
+        onRequestRemove={() => null}
+        onRequestPin={() => null}
+        isPinned={false}
+      />
+    );
+
+    setImmediate(() => {
+      wrapper.update();
+      const icon = wrapper
+        .find('.actions')
+        .find(Icon)
+        .filter({ name: 'picture' });
+      expect(icon).toHaveLength(0);
+      done();
+    });
+  });
+
+  test('shows alternative printings button if more than one printing', done => {
+    const wrapper = mount(
+      <CardResult
+        name="Goblin Balloon Brigade"
+        onRequestRemove={() => null}
+        onRequestPin={() => null}
+        isPinned={false}
+      />
+    );
+
+    setImmediate(() => {
+      wrapper.update();
+      const icon = wrapper
+        .find('.actions')
+        .find(Icon)
+        .filter({ name: 'picture' });
+      expect(icon).toHaveLength(1);
+      expect(icon.parent().is('button')).toBe(true);
       done();
     });
   });

--- a/__tests__/components/PrintingsModal.test.js
+++ b/__tests__/components/PrintingsModal.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PrintingsModal from '../../components/PrintingsModal';
+import { mount } from 'enzyme';
+
+describe('PrintingsModal', () => {
+  afterEach(() => {
+    const modal = document.querySelector('.modal');
+    if (modal) modal.remove();
+  });
+
+  const mockCardsData = [
+    {
+      id: '1',
+      image_uris: {
+        large: 'image uri',
+      },
+      scryfall_uri: 'card uri',
+      rulings_uri: 'rulings uri',
+      set_name: 'set name',
+      set: 'set',
+    },
+    {
+      id: '2',
+      image_uris: {
+        large: 'image uri',
+      },
+      scryfall_uri: 'card uri',
+      rulings_uri: 'rulings uri',
+      set_name: 'set name two',
+      set: 'st2',
+    },
+  ];
+
+  test('renders a number of links appropriate to the number of cards', () => {
+    const wrapper = mount(
+      <PrintingsModal
+        selectCard={jest.fn()}
+        onClose={jest.fn()}
+        isOpen
+        allPrintings={mockCardsData}
+      />
+    );
+
+    const modal = document.querySelector('.modal');
+    expect(modal).toBeDefined();
+    expect(modal.querySelectorAll('h4')).toHaveLength(2);
+  });
+
+  test('renders the set and card names', () => {
+    const wrapper = mount(
+      <PrintingsModal
+        selectCard={jest.fn()}
+        onClose={jest.fn()}
+        isOpen
+        allPrintings={mockCardsData}
+      />
+    );
+
+    const modal = document.querySelector('.modal');
+    expect(modal).toBeDefined();
+    expect(modal.querySelectorAll('h4')[0].innerHTML).toContain('set name');
+    expect(modal.querySelectorAll('h4')[0].innerHTML).toContain('set');
+  });
+});

--- a/components/CardResult.js
+++ b/components/CardResult.js
@@ -33,6 +33,14 @@ export default class CardResult extends Component {
     isPrintingsModalOpen: false,
   };
 
+  selectCard = id => {
+    // get the card
+    const { allPrintings } = this.state;
+    const card = allPrintings.find(card => card.id === id);
+    this.setState({ card });
+    this.closePrintingsModal();
+  };
+
   componentDidMount() {
     const { name } = this.props;
     fetch(
@@ -187,6 +195,7 @@ export default class CardResult extends Component {
             allPrintings={allPrintings}
             isOpen={isPrintingsModalOpen}
             onClose={this.closePrintingsModal}
+            selectCard={this.selectCard}
           />
         )}
 

--- a/components/CardResult.js
+++ b/components/CardResult.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Segment, Icon } from 'semantic-ui-react';
 import RulingsModal from './RulingsModal';
 import OracleModal from './OracleModal';
+import PrintingsModal from './PrintingsModal';
 import { getImageSources, isDoubleFaced } from '../utils/card-data';
 import CardImage from './CardImage';
 import cx from 'classnames';
@@ -24,20 +25,33 @@ export default class CardResult extends Component {
 
   state = {
     card: null,
+    allPrintings: null,
     rulings: [],
     faceIndex: 0,
     isOracleModalOpen: false,
     isRulingsModalOpen: false,
+    isPrintingsModalOpen: false,
   };
 
   componentDidMount() {
     const { name } = this.props;
     fetch(
-      `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(name)}`
+      `https://api.scryfall.com/cards/search?order=released&q=%21%E2%80%9C${encodeURIComponent(
+        name
+      )}%E2%80%9D+include%3Aextras&unique=prints`
     )
       .then(result => result.json())
-      .then(card => {
+      .then(result => {
+        const cards = result.data;
+        const card = cards[0];
         this.setState({ card });
+        if (cards.length > 1) {
+          const allPrintings = [];
+          cards.forEach(card => {
+            allPrintings.push(card);
+          });
+          this.setState({ allPrintings });
+        }
         return fetch(card.rulings_uri);
       })
       .then(result => result.json())
@@ -103,13 +117,23 @@ export default class CardResult extends Component {
     this.setState({ isRulingsModalOpen: false });
   };
 
+  openPrintingsModal = () => {
+    this.setState({ isPrintingsModalOpen: true });
+  };
+
+  closePrintingsModal = () => {
+    this.setState({ isPrintingsModalOpen: false });
+  };
+
   render() {
     const {
       card,
+      allPrintings,
       rulings,
       faceIndex,
       isOracleModalOpen,
       isRulingsModalOpen,
+      isPrintingsModalOpen,
     } = this.state;
     const { onRequestRemove, onRequestPin, isPinned, isFocused } = this.props;
     const imageSources = getImageSources(card);
@@ -150,8 +174,21 @@ export default class CardResult extends Component {
                 <Icon name="refresh" />
               </Button>
             )}
+            {allPrintings && (
+              <Button icon onClick={this.openPrintingsModal}>
+                <Icon name="picture" />
+              </Button>
+            )}
           </Button.Group>
         </div>
+
+        {allPrintings && (
+          <PrintingsModal
+            allPrintings={allPrintings}
+            isOpen={isPrintingsModalOpen}
+            onClose={this.closePrintingsModal}
+          />
+        )}
 
         {card && (
           <OracleModal

--- a/components/PrintingsModal.js
+++ b/components/PrintingsModal.js
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import { Modal, Grid } from 'semantic-ui-react';
+
+const PrintingsModal = ({ allPrintings, isOpen, onClose }) => (
+  <Modal closeIcon onClose={onClose} open={isOpen}>
+    <Modal.Header>Select printing/art to display</Modal.Header>
+    <Modal.Content>
+      <Grid>
+        <Grid.Column computer="12" mobile="16">
+          {allPrintings.map(card => (
+            <h3 key={card.id}>
+              {card.set} {card.set_name}
+            </h3>
+          ))}
+        </Grid.Column>
+      </Grid>
+    </Modal.Content>
+  </Modal>
+);
+
+PrintingsModal.propTypes = {
+  allPrintings: PropTypes.array.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default PrintingsModal;

--- a/components/PrintingsModal.js
+++ b/components/PrintingsModal.js
@@ -1,24 +1,35 @@
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Grid } from 'semantic-ui-react';
 
-const PrintingsModal = ({ allPrintings, isOpen, onClose }) => (
-  <Modal closeIcon onClose={onClose} open={isOpen}>
-    <Modal.Header>Select printing/art to display</Modal.Header>
-    <Modal.Content>
-      <Grid>
-        <Grid.Column computer="12" mobile="16">
-          {allPrintings.map(card => (
-            <h3 key={card.id}>
-              {card.set} {card.set_name}
-            </h3>
-          ))}
-        </Grid.Column>
-      </Grid>
-    </Modal.Content>
-  </Modal>
-);
+class PrintingsModal extends Component {
+  onPrintingSelect = e => {
+    const cardID = e.target.id;
+    this.props.selectCard(cardID);
+  };
+  render() {
+    const { allPrintings, isOpen, onClose } = this.props;
+    return (
+      <Modal closeIcon onClose={onClose} open={isOpen}>
+        <Modal.Header>Select printing/art to display</Modal.Header>
+        <Modal.Content>
+          <Grid>
+            <Grid.Column computer="12" mobile="16">
+              {allPrintings.map(card => (
+                <h4 key={card.id} id={card.id} onClick={this.onPrintingSelect}>
+                  {card.set_name} ({card.set})
+                </h4>
+              ))}
+            </Grid.Column>
+          </Grid>
+        </Modal.Content>
+      </Modal>
+    );
+  }
+}
 
 PrintingsModal.propTypes = {
+  selectCard: PropTypes.func.isRequired,
   allPrintings: PropTypes.array.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/components/PrintingsModal.js
+++ b/components/PrintingsModal.js
@@ -4,6 +4,7 @@ import { Modal, Grid } from 'semantic-ui-react';
 
 class PrintingsModal extends Component {
   onPrintingSelect = e => {
+    e.preventDefault();
     const cardID = e.target.id;
     this.props.selectCard(cardID);
   };
@@ -16,8 +17,10 @@ class PrintingsModal extends Component {
           <Grid>
             <Grid.Column computer="12" mobile="16">
               {allPrintings.map(card => (
-                <h4 key={card.id} id={card.id} onClick={this.onPrintingSelect}>
-                  {card.set_name} ({card.set})
+                <h4 key={card.id}>
+                  <a id={card.id} onClick={this.onPrintingSelect} href="">
+                    {card.set_name} ({card.set})
+                  </a>
                 </h4>
               ))}
             </Grid.Column>


### PR DESCRIPTION
This branch adds support for changing the version of the card to display.

So the idea for this came up whilst watching coverage of a Legacy GP. My brother and I were trying to ascertain what land one of the players had in play. We had a couple of theories but wanted to compare two card arts to see which looked more likely. This app came to mind as the easiest way to have two cards side to side. Unfortunately the arts that came up for the lands were the ones from MTGO so we couldn't compare them properly.

- I've implemented it as a rewrite of the way data is handled - all printings of a card are stored rather than a singular card. I'm not sure if this is the best way but it felt like the simplest way to add the functionality without changing too much.
- This is my first work on something in React that hasn't been a personal project so I may have done some things sub-optimally!
- I wanted to discuss the merits of even having this feature; it may not be worthwhile or better implemented in a different way.

- Some to-dos:
  - [ ] Add presser/keyboard shortcut
  - [ ] Display the sets better
    - Right now, the printings selection is given on a modal as a list of links, but a `<select>` element may be more appropriate? Currently the UI doesn't look so nice for cards with a lot of printings.

- I learnt a lot from looking at the project and I think it's a really useful tool!